### PR TITLE
Delete pre-release tag if already exists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ deploy:
       condition: $TRAVIS_GO_VERSION =~ ^1\.7\.[0-9]+$
       tags: true
   - provider: script
-    script: ghr --username seiffert --token $GITHUB_TOKEN --replace --prerelease --debug pre-release dist/
+    script: ghr --username seiffert --token $GITHUB_TOKEN --delete --prerelease --debug pre-release dist/
     skip_cleanup: true
     on: 
       condition: $TRAVIS_GO_VERSION =~ ^1\.7\.[0-9]+$


### PR DESCRIPTION
In order to have the latest pre-release on top of the GitHub releases page.